### PR TITLE
using session storage + browser history + quesition navigation buttons

### DIFF
--- a/javascript/webquiz.js
+++ b/javascript/webquiz.js
@@ -244,6 +244,8 @@ function updateQuestionMarker(bnum, qnum) {
 
 // jumps to a chosen question and pushes the number of this question to the browser history
 function gotoQuestion(bnum) {
+    // bnum is a button number so we need to convert to a question number
+    
     var qnum = (bnum>0) ? questionOrder[bnum] : bnum;
     gotoQuestionHelper(qnum);
     history.pushState(qnum, null, null);

--- a/javascript/webquiz.js
+++ b/javascript/webquiz.js
@@ -20,6 +20,7 @@ var buttonOrder = [];       // map from button number to question number
 var questionOrder = [];     // map from question number to button number
 var wrongAnswers = [];      // questions answered incorrectly
 
+
 var currentB;               // current button number
 var currentFeedback = null; // feedback currently being displayed
 var currentQ;               // current question number
@@ -57,6 +58,13 @@ var tick = {
     "name": "tick"
 };
 
+function markAnswer() {
+  if (typeof(Storage) !== "undefined") {
+    sessionStorage.correct = JSON.stringify(correct);
+    sessionStorage.wrongAnswers = JSON.stringify(wrongAnswers);
+  }
+}
+ 
 // stop the dropdown menu from being created twice
 var quizindex_menu_not_created = true;
 
@@ -234,10 +242,16 @@ function updateQuestionMarker(bnum, qnum) {
     }
 }
 
+// jumps to a chosen question an pushes the nr of this question to the browser history
 function gotoQuestion(bnum) {
-    // bnum is a button number so we need to convert to a question number
-
     var qnum = (bnum>0) ? questionOrder[bnum] : bnum;
+    gotoQuestionHelper(qnum);
+    history.pushState(qnum, null, null);
+}
+
+// jumps to question corresponding to bnum-th button 
+function gotoQuestionHelper(qnum) { 
+    var bnum = (qnum>0) ? buttonOrder[qnum] : qnum;
     updateQuestionMarker(bnum, qnum);
     showQuestion(bnum, qnum);
 }
@@ -320,6 +334,7 @@ function checkAnswer(qnum) {
         wrongAnswers[qnum] += 1;
     }
     updateQuestionMarker(buttonOrder[qnum], qnum);
+    markAnswer(); 
 }
 
 /**
@@ -340,9 +355,33 @@ function shuffleQuestions() {
     }
 }
 
+// Restores the state of the question markers from the session storage 
+function initSession() {
+    if (typeof(Storage) !== "undefined") {
+      if (sessionStorage.correct)
+        correct = JSON.parse(sessionStorage.correct);
+      if (sessionStorage.wrongAnswers)
+        wrongAnswers = JSON.parse(sessionStorage.wrongAnswers);
+    }
+
+    for (i = 0; i < qTotal+1; i++) { 
+      updateQuestionMarker(buttonOrder[i],i); 
+    }
+
+    // make the browser history remember the first question
+    qnum = (dTotal > 0) ? -1 : questionOrder[1];
+    history.replaceState(qnum, null, null);
+}
+
 // initialise the quiz, loading specifications and setting up the first question
 function WebQuizInit(questions, discussions, quizfile) {
     // process init options
+
+    // callback for browser history events 
+    window.addEventListener('popstate', function(e) {
+       gotoQuestionHelper(e.state);
+    });
+    
     qTotal = questions;
     dTotal = discussions;
 

--- a/javascript/webquiz.js
+++ b/javascript/webquiz.js
@@ -242,14 +242,14 @@ function updateQuestionMarker(bnum, qnum) {
     }
 }
 
-// jumps to a chosen question an pushes the nr of this question to the browser history
+// jumps to a chosen question and pushes the number of this question to the browser history
 function gotoQuestion(bnum) {
     var qnum = (bnum>0) ? questionOrder[bnum] : bnum;
     gotoQuestionHelper(qnum);
     history.pushState(qnum, null, null);
 }
 
-// jumps to question corresponding to bnum-th button 
+// jumps to the specified question (without pushing it to the browser history) 
 function gotoQuestionHelper(qnum) { 
     var bnum = (qnum>0) ? buttonOrder[qnum] : qnum;
     updateQuestionMarker(bnum, qnum);

--- a/latex/webquiz.cls
+++ b/latex/webquiz.cls
@@ -372,5 +372,29 @@
 \def\whenRight{\WQ@When{right}}
 \def\whenWrong{\WQ@When{wrong}}
 
+% ---------------------------------------------------------------------------
+% Navigation buttons \questionButton \questionLink
+%
+% these insert a button or link, which takes the user to the question given
+% in the second argument. The first argument gives the text for the button / link.
+% ---------------------------------------------------------------------------
+
+\ifdefined\HCode % when called by make4th insert html code
+\NewDocumentCommand\questionButton{mm}{%
+  \HCode{<input type="button" value="#1" class="input-button" title="#1" name="next" onClick="gotoQuestion(#2);"/>}
+}
+\NewDocumentCommand\questionLink{mm}{%
+  \HCode{<a href="javascript:gotoQuestion(#2);">#1</a>}
+  }
+\else % when called by LaTeX show button text / link text and describe the intended action
+\NewDocumentCommand\questionButton{mm}{%
+  \framebox{#1 (jumps to question #2)}
+}
+\NewDocumentCommand\questionLink{mm}{%
+  \underline{#1} (jumps to question #2)
+  }
+\fi
+
+
 \endinput
 %% End of file `webquiz.cls'.

--- a/webquiz/webquiz_makequiz.py
+++ b/webquiz/webquiz_makequiz.py
@@ -342,7 +342,7 @@ class MakeWebQuiz(object):
                     quiz_specs.write('onePage = true;\n')
                 if self.quiz.random_order:
                     quiz_specs.write('shuffleQuestions();\n')
-
+                quiz_specs.write('initSession();\n')
                 if self.number_discussions+self.number_questions>0:
                     quiz_specs.write('gotoQuestion({});'.format(
                         -1 if self.number_discussions>0 else 1)


### PR DESCRIPTION
1. I used session storage in javascript to save the correct answers and
wrong attempts. Hence, a reload of the page doesn't reset the question
status (but reopen it in a new tab does). One could also save the status
permanently in localstorage (until the user decides to delete
cookies/local storage), but I am not sure whether this is really what I
want.

2. I added some javascript code to make the browser history work as
expected (i.e. "back in history" goes to the question which was shown
before).

3. I added the possibility to integrate links to question within a
discussion (or even question environment). It can be used e.g. to 
produce a "Start Quiz" button at the initial discussion page, but there might be other
use of it, e.g. giving the user a choice which follow-up question he/she
wants to attempt next.